### PR TITLE
feat: general ui fixes

### DIFF
--- a/apps/account-server/src/components/dialog/dialog.tsx
+++ b/apps/account-server/src/components/dialog/dialog.tsx
@@ -99,18 +99,18 @@ export const DialogHeader = ({
 export const DialogFooter = ({
   showLegalNotice,
   actions,
-  isFixed,
+  addBackground,
 }: {
   showLegalNotice: boolean;
   actions: React.ReactNode;
-  isFixed: boolean;
+  addBackground: boolean;
 }) => {
   return (
     <div
       className={cn(
-        'mt-6 max-w-[400px]',
-        isFixed
-          ? 'fixed bottom-0 left-0 right-0 bg-white z-10 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)] mx-auto'
+        'mt-6 max-w-[400px] fixed bottom-0 left-0 right-0',
+        addBackground
+          ? ' bg-white z-10 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)] mx-auto'
           : '',
       )}
     >
@@ -118,7 +118,14 @@ export const DialogFooter = ({
         {showLegalNotice && <LegalNotice />}
         {actions}
         <div className="flex items-center justify-center gap-2 text-sm mt-3 -my-2">
-          Powered by <IconSophon className="w-8 h-8" />
+          <a
+            className="flex items-center gap-2"
+            href="https://sophon.xyz"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Powered by <IconSophon className="w-8 h-8" />
+          </a>
         </div>
       </div>
     </div>
@@ -233,7 +240,7 @@ export function Dialog({
         <DialogFooter
           showLegalNotice={showLegalNotice}
           actions={actions}
-          isFixed={isScrollable}
+          addBackground={isScrollable}
         />
       </div>
     </div>

--- a/apps/account-server/src/components/transaction-views/ApprovalTransactionView.tsx
+++ b/apps/account-server/src/components/transaction-views/ApprovalTransactionView.tsx
@@ -1,4 +1,4 @@
-import { truncateName } from '@/lib/formatting';
+import { truncateContractName } from '@/lib/formatting';
 import type { EnrichedApprovalTransaction } from '@/types/auth';
 import { AddressLink } from './shared';
 
@@ -14,20 +14,16 @@ export default function ApprovalTransactionView({
       <div className="text-left flex flex-col gap-1">
         <p className="text-xs font-bold">Contract:</p>
         <p className="text-sm text-black">
-          <span className="">
-            {truncateName(transaction.spender.name || '')}
-          </span>{' '}
-          @ <AddressLink address={transaction.spender.address} />
+          <span>{truncateContractName(transaction.spender.name || '')}</span> @{' '}
+          <AddressLink address={transaction.spender.address} />
         </p>
       </div>
 
       <div className="text-left flex flex-col gap-1">
         <p className="text-xs font-bold">Token:</p>
         <p className="text-sm text-black">
-          <span className="">
-            {truncateName(transaction.token.tokenName || '')}
-          </span>{' '}
-          @ <AddressLink address={transaction.token.contractAddress} />
+          <span>{transaction.token.tokenName || ''}</span> @{' '}
+          <AddressLink address={transaction.token.contractAddress} />
         </p>
       </div>
 

--- a/apps/account-server/src/components/transaction-views/ContractTransactionView.tsx
+++ b/apps/account-server/src/components/transaction-views/ContractTransactionView.tsx
@@ -1,4 +1,4 @@
-import { truncateName } from '@/lib/formatting';
+import { truncateContractName } from '@/lib/formatting';
 import type { EnrichedContractTransaction } from '@/types/auth';
 import { AddressLink, renderParameterValue } from './shared';
 
@@ -14,10 +14,8 @@ export default function ContractTransactionView({
       <div className="text-left flex flex-col gap-1">
         <p className="text-sm font-bold">Interacting with:</p>
         <p className="text-sm text-black">
-          <span className="font-bold truncate block">
-            {truncateName(transaction.contractName || '')}
-          </span>{' '}
-          @ <AddressLink address={transaction.recipient} />
+          <span>{truncateContractName(transaction.contractName || '')}</span> @{' '}
+          <AddressLink address={transaction.recipient} />
         </p>
       </div>
 
@@ -44,8 +42,9 @@ export default function ContractTransactionView({
       {transaction.displayValue !== '0' && (
         <div className="text-left">
           <p className="text-sm text-black">
-            You are sending {transaction.displayValue} SOPH for this transaction
-            to the contract above.
+            You are sending{' '}
+            <span className="font-bold">{transaction.displayValue} SOPH</span>{' '}
+            for this transaction to the contract above.
           </p>
         </div>
       )}

--- a/apps/account-server/src/components/transaction-views/shared/ContractWarning.tsx
+++ b/apps/account-server/src/components/transaction-views/shared/ContractWarning.tsx
@@ -9,9 +9,9 @@ interface ContractWarningProps {
 export default function ContractWarning({ transaction }: ContractWarningProps) {
   if (transaction.transactionType === TransactionType.APPROVE) {
     return (
-      <Card elevated className="p-4 flex items-center gap-5 w-full">
+      <Card elevated className="py-4 px-6 flex items-center gap-4 w-full">
         <InfoIcon weight="fill" className="w-6 h-6 text-[#A3A2A0]" />
-        <p className="text-xs text-black flex-1 text-left">
+        <p className="text-xs text-black flex-1 text-left max-w-[264px]">
           You will give permission for the following contract to spend tokens on
           your behalf.
         </p>
@@ -25,9 +25,9 @@ export default function ContractWarning({ transaction }: ContractWarningProps) {
     }
 
     return (
-      <Card elevated className="p-4 flex items-center gap-5 w-full">
+      <Card elevated className="py-4 px-6 flex items-center gap-4 w-full">
         <WarningCircleIcon weight="fill" className="w-6 h-6 text-red-500" />
-        <p className="text-xs text-black flex-1 text-left">
+        <p className="text-xs text-black flex-1 text-left max-w-[264px]">
           This contract is not verified, and for this reason it is not possible
           to show the transaction details. Make sure you trust it before
           proceeding.

--- a/apps/account-server/src/components/transaction-views/shared/TokenDetails.tsx
+++ b/apps/account-server/src/components/transaction-views/shared/TokenDetails.tsx
@@ -1,4 +1,3 @@
-import { truncateName } from '@/lib/formatting';
 import type { Token } from '@/types/auth';
 import AddressLink from './AddressLink';
 
@@ -11,7 +10,7 @@ export default function TokenDetails({ token }: TokenDetailsProps) {
     <div className="flex flex-col gap-1">
       <p className="text-xs font-bold">Token:</p>
       <p className="text-sm text-black">
-        <span className="">{truncateName(token.tokenName || '')}</span> @{' '}
+        <span className="">{token.tokenName || ''}</span> @{' '}
         <AddressLink address={token.contractAddress} />
       </p>
     </div>

--- a/apps/account-server/src/components/transaction-views/shared/TransactionIcon.tsx
+++ b/apps/account-server/src/components/transaction-views/shared/TransactionIcon.tsx
@@ -21,6 +21,8 @@ export default function TransactionIcon({ transaction }: TransactionIconProps) {
   switch (transaction.transactionType) {
     case TransactionType.APPROVE:
       return <CoinsIcon weight="fill" className="w-10 h-10 text-white" />;
+    case TransactionType.ERC20:
+      return <CoinsIcon weight="fill" className="w-10 h-10 text-white" />;
     default:
       return <ReceiptIcon weight="fill" className="w-10 h-10 text-white" />;
   }

--- a/apps/account-server/src/components/transaction-views/shared/TransactionIcon.tsx
+++ b/apps/account-server/src/components/transaction-views/shared/TransactionIcon.tsx
@@ -20,7 +20,6 @@ export default function TransactionIcon({ transaction }: TransactionIconProps) {
   // Fall back to transaction type-specific icons
   switch (transaction.transactionType) {
     case TransactionType.APPROVE:
-      return <CoinsIcon weight="fill" className="w-10 h-10 text-white" />;
     case TransactionType.ERC20:
       return <CoinsIcon weight="fill" className="w-10 h-10 text-white" />;
     default:

--- a/apps/account-server/src/components/ui/messageContainer.tsx
+++ b/apps/account-server/src/components/ui/messageContainer.tsx
@@ -11,10 +11,10 @@ export default function MessageContainer({
     <Card
       elevated
       className={`mt-4 px-6 pt-6 ${
-        showBottomButton ? 'pb-[4.5rem]' : 'pb-6'
-      } overflow-y-auto text-left w-full relative`}
+        showBottomButton ? 'pb-[3.5rem]' : 'pb-6'
+      } overflow-y-auto text-left w-full relative max-w-[352px]`}
     >
-      <div className="text-sm text-black h-full break-all">{children}</div>
+      <div className="text-sm text-black h-full break-words">{children}</div>
     </Card>
   );
 }

--- a/apps/account-server/src/hooks/enrichers/approve-enricher.ts
+++ b/apps/account-server/src/hooks/enrichers/approve-enricher.ts
@@ -1,4 +1,4 @@
-import { formatEther } from 'viem';
+import { formatEther, formatUnits } from 'viem';
 import type {
   EnrichedApprovalTransaction,
   TransactionRequest,
@@ -22,7 +22,10 @@ export const enrichApprovalTransaction = async (
     recipient: transactionRequest.to,
     token: {
       ...token,
-      currentBalance: currentBalance || '0',
+      currentBalance: formatUnits(
+        BigInt(currentBalance || '0'),
+        Number(token.tokenDecimal),
+      ),
     },
     displayValue: formatEther(BigInt(transactionRequest.value || '0')),
     spender: {

--- a/apps/account-server/src/hooks/useRequestDrawer.tsx
+++ b/apps/account-server/src/hooks/useRequestDrawer.tsx
@@ -69,7 +69,7 @@ export const useRequestDrawer = () => {
               {isSponsored ? (
                 <div className=" rounded-lg p-3">
                   <div className="text-sm break-all">
-                    <span className="mr-1">Sponsored by Paymaster at:</span>
+                    <span className="mr-1">Sponsored by Paymaster @</span>
                     <AddressLink address={data.paymaster || ''} />
                   </div>
                 </div>
@@ -109,6 +109,7 @@ export const useRequestDrawer = () => {
   };
 
   const DrawerComponent = () => {
+    const [isOpen, setIsOpen] = useState(drawerState.isOpen);
     const title =
       drawerState.contentType === 'raw-transaction'
         ? 'Raw Transaction'
@@ -121,18 +122,23 @@ export const useRequestDrawer = () => {
               : '';
 
     return (
-      <VaulDrawer.Root open={drawerState.isOpen} onOpenChange={closeDrawer}>
+      <VaulDrawer.Root open={isOpen} onOpenChange={setIsOpen}>
         <VaulDrawer.Portal>
           <VaulDrawer.Overlay className="fixed inset-0 bg-black/40" />
-          <VaulDrawer.Content className="bg-white h-fit max-h-[80vh] fixed bottom-0 left-0 right-0 outline-none rounded-t-3xl overflow-hidden">
+          <VaulDrawer.Content className="bg-white h-fit max-h-[80vh] fixed bottom-0 left-0 right-0 outline-none rounded-t-3xl overflow-hidden z-50">
             <VaulDrawer.Handle className="mt-4 w-[67px]" />
             <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center">
               <VaulDrawer.Title className="text-xl font-semibold text-center flex-1">
                 {title}
               </VaulDrawer.Title>
-              <VaulDrawer.Close asChild>
-                <XIcon size={16} className="text-black cursor-pointer" />
-              </VaulDrawer.Close>
+              <button
+                onClick={() => setIsOpen(false)}
+                type="button"
+                className="text-black hover:opacity-70 transition-opacity"
+                aria-label="Close drawer"
+              >
+                <XIcon size={16} className="cursor-pointer" />
+              </button>
             </div>
 
             <div className="overflow-auto max-h-[60vh]">

--- a/apps/account-server/src/lib/formatting.ts
+++ b/apps/account-server/src/lib/formatting.ts
@@ -19,11 +19,7 @@ export function maskEmail(email: string) {
   return `${localPart.slice(0, 2)}...${localPart.slice(-1)}@${domain}`;
 }
 
-export function truncateName(
-  text: string,
-  startLength: number = 10,
-  endLength: number = 10,
-) {
-  if (text.length <= startLength + endLength + 3) return text;
-  return `${text.slice(0, startLength)}...${text.slice(-endLength)}`;
+export function truncateContractName(text: string) {
+  const name = text.replace(/.*\.(sol|vy):/, '');
+  return name;
 }

--- a/apps/account-server/src/views/LoadingView.tsx
+++ b/apps/account-server/src/views/LoadingView.tsx
@@ -26,7 +26,7 @@ export const LoadingView = ({ message }: { message?: string }) => {
   return (
     <div
       className={`flex flex-col items-center justify-center gap-8 mt-3 flex-grow ${
-        !isMobile ? 'h-full' : ''
+        !isMobile ? 'h-[calc(100vh-100px)]' : ''
       }`}
     >
       {socialProvider ? (

--- a/apps/account-server/src/views/SigningRequestView.tsx
+++ b/apps/account-server/src/views/SigningRequestView.tsx
@@ -37,8 +37,8 @@ export default function SigningRequestView({
       {typedDataSigning && (
         <div>
           <Card>
-            <div className="w-full flex justify-between px-6 py-4">
-              <p className="text-xs font-bold">Primary Type</p>
+            <div className="w-full flex justify-between items-center px-6 py-4">
+              <p className="text-sm font-bold">Primary Type</p>
               <p className="text-sm text-black">
                 {typedDataSigning.primaryType}
               </p>


### PR DESCRIPTION
- don't use break all in messageContainer
- wrong icon for erc20 tx (receipt vs coin)
- missing our link on footer (link to sophon.xyz)
- We need to parse contract name to only show last file name (copy fro explorer)  
 - for token approval, current balance is not considering decimals  
- page seems to be growing to fit content, instead of having footer footer fixed to bottom (and then whole page scrolling)
- Contract name shouldn’t be bold on basic contract page (on the interacting with part)  
- bottom sheet disappears when closed instead of having the animation  
- “alert” component - gap between icon and text/border is not even on both sides  
- Missing BOLD on SOPH amount (when tx has msg.value)  
- Sponsored by Paymaster at: -> Sponsored by Paymaster @  
- Sign typed message -> the “Primary type” seems to have the wrong font size and vertical aligment  
- MessageConatainer - extra bottom padding between end of content and the “View raw” part