### PR TITLE
feat(SOP-1538): waiting for message before initializing the modal

### DIFF
--- a/apps/account-server/src/hooks/useMessageHandler.ts
+++ b/apps/account-server/src/hooks/useMessageHandler.ts
@@ -244,7 +244,12 @@ export const useMessageHandler = (): UseMessageHandlerReturn => {
 
     // Define the message handler
     const unregister = windowService.listen(messageHandler);
-    setHandlerInitialized(true);
+
+    // wait a little before setting the handle initialized to give
+    // time for the caller messages to be receive and avoid visual glitches
+    setTimeout(() => {
+      setHandlerInitialized(true);
+    }, 500);
 
     return () => {
       unregister();


### PR DESCRIPTION
The problem here is between the window <-> opener communication. We get the messages listener up, but while the message doesn't arrive it shows as expected the login time. For now we wait a little more, after we finish the mobile part we can have a better view on a more deterministic flow.