### PR TITLE
[SOP-1602] Fix: Drawer height on Connect Authorization view

### DIFF
--- a/apps/account-server/src/components/ui/drawer.tsx
+++ b/apps/account-server/src/components/ui/drawer.tsx
@@ -199,7 +199,7 @@ export const Drawer = ({
       <VaulDrawer.Portal>
         <VaulDrawer.Overlay className="fixed inset-0 bg-black/40" />
         <VaulDrawer.Content
-          className="bg-gray-100 fixed outline-none rounded-t-3xl"
+          className="bg-gray-100 fixed outline-none rounded-t-3xl flex flex-col max-h-[85vh]"
           style={{
             bottom: `${insets.bottom}px`,
             left: `${insets.left}px`,
@@ -223,15 +223,17 @@ export const Drawer = ({
           )}
           <div
             ref={scrollContainerRef}
-            className={`overflow-y-auto max-h-[60vh] px-4 pb-4`}
+            className={`overflow-y-auto flex-1 min-h-0 px-4 pb-4`}
           >
             {isOffline ? <OfflineContent /> : children}
           </div>
-          <DrawerFooter
-            showLegalNotice={showLegalNotice}
-            showLogo={showLogo}
-            actions={actions}
-          />
+          <div className="flex-shrink-0">
+            <DrawerFooter
+              showLegalNotice={showLegalNotice}
+              showLogo={showLogo}
+              actions={actions}
+            />
+          </div>
         </VaulDrawer.Content>
       </VaulDrawer.Portal>
     </VaulDrawer.Root>


### PR DESCRIPTION
Despite still not being able to reproduce the bug on different development environments, we could attempt to fix drawer height bug on Connect Authorization view by:

- Setting total drawer to occupy 85% of viewport height, creating more space for content;
- Adding flexbox layout for proper space distribution;
- Content area now takes available space but can shrink;
- Footer (action buttons) never shrinks and stays visible.